### PR TITLE
Explicitly convert literal string to QString.

### DIFF
--- a/src/GoogleDrive/msgoogledrive.cpp
+++ b/src/GoogleDrive/msgoogledrive.cpp
@@ -1331,10 +1331,10 @@ void MSGoogleDrive::doSync(){
 
     QJsonDocument state;
     QJsonObject jso;
-    jso.insert("change_stamp","0");
+    jso.insert("change_stamp",QString("0"));
 
     QJsonObject jts;
-    jts.insert("nsec","0");
+    jts.insert("nsec",QString("0"));
     jts.insert("sec",QString::number(QDateTime( QDateTime::currentDateTime()).toMSecsSinceEpoch()));
 
     jso.insert("last_sync",jts);
@@ -1774,7 +1774,7 @@ void MSGoogleDrive::remote_file_makeFolder(MSFSObject *object){
     //make file metadata in json representation
     QJsonObject metaJson;
     metaJson.insert("title",object->fileName);
-    metaJson.insert("mimeType","application/vnd.google-apps.folder");
+    metaJson.insert("mimeType",QString("application/vnd.google-apps.folder"));
 
     metaData.append(QString(QJsonDocument(metaJson).toJson()).toLocal8Bit());
 
@@ -1821,7 +1821,7 @@ void MSGoogleDrive::remote_file_makeFolder(MSFSObject *object, QString parentID)
     //make file metadata in json representation
     QJsonObject metaJson;
     metaJson.insert("title",object->fileName);
-    metaJson.insert("mimeType","application/vnd.google-apps.folder");
+    metaJson.insert("mimeType",QString("application/vnd.google-apps.folder"));
 
     if(parentID != ""){
         // create parents section


### PR DESCRIPTION
I found these changes necessary in order to build the application on my system.

`$ qmake --version
QMake version 3.0
Using Qt version 5.2.1 in /usr/lib/x86_64-linux-gnu
$ g++ --version
g++ (Ubuntu 4.8.4-2ubuntu1~14.04) 4.8.4
Copyright (C) 2013 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
$ uname -srvmpio
Linux 3.13.0-51-generic #84-Ubuntu SMP Wed Apr 15 12:08:34 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux
$`
