### PR TITLE
Removed excess indirection

### DIFF
--- a/src/common/msoptparser.cpp
+++ b/src/common/msoptparser.cpp
@@ -155,7 +155,7 @@ void MSOptParser::parse(QStringList list){
     }
 
     this->iit=this->input.begin();
-    *this->iit++;
+    this->iit++;
 }
 
 


### PR DESCRIPTION
Убрано лишнее разыменование итератора при переводе итератора с нулевого индекса во время разбора аргументов командной строки