### PR TITLE
Using * in include & exclude lists

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -126,6 +126,7 @@ void printHelp(){
     qStdOut()<< QObject::tr("   --socks5-proxy arg         Use socks5 proxy server for connection to cloud provider. \n"
                             "                              <arg> must be in a ip_address_or_host_name:port_number format") <<endl;
     qStdOut()<< QObject::tr("   --cloud-space              Showing total and free space  of cloud \n")<<endl;
+    qStdOut()<< QObject::tr("   --filter-type              Filter type for .include and .exclude files. Ignored if it set in files") <<endl;
 }
 
 
@@ -937,6 +938,7 @@ int main(int argc, char *argv[])
     parser->insertOption(18,"--socks5-proxy 1");
 
     parser->insertOption(19,"--cloud-space");
+    parser->insertOption(20,"--filter-type 1");
 
 
     //...............
@@ -1379,12 +1381,14 @@ int main(int argc, char *argv[])
                 default:
                     break;
 
-                }
+            }
 
             return 0;
             break;
-
-
+        case 20: // --filter-type
+            qStdOut() << "=========================================" << parser->optarg[0] << endl;
+            providers->setOption("filter-type",parser->optarg[0]);
+            break;
         default: // syn execute without any params by default
 
             switch(currentProvider){

--- a/src/Dropbox/msdropbox.cpp
+++ b/src/Dropbox/msdropbox.cpp
@@ -611,7 +611,7 @@ bool MSDropbox::createSyncFileList(){
             QString line;
             while(!instream.atEnd()){
 
-                QString line=instream.readLine();
+                line=instream.readLine();
                 if(line.isEmpty()){
                         continue;
                 }
@@ -619,6 +619,7 @@ bool MSDropbox::createSyncFileList(){
                 this->includeList=this->includeList+line+"|";
             }
             this->includeList=this->includeList.left(this->includeList.size()-1);
+            this->includeList.replace("*",".*");
 
             QRegularExpression regex2(this->includeList);
 
@@ -626,7 +627,6 @@ bool MSDropbox::createSyncFileList(){
                 qStdOut()<<"Include filelist contains errors. Program will be terminated.";
                 return false;
             }
-
         }
     }
     else{
@@ -638,13 +638,14 @@ bool MSDropbox::createSyncFileList(){
             QString line;
             while(!instream.atEnd()){
 
-                QString line=instream.readLine();
+                line=instream.readLine();
                 if(line.isEmpty()){
                         continue;
                 }
                 this->excludeList=this->excludeList+line+"|";
             }
             this->excludeList=this->excludeList.left(this->excludeList.size()-1);
+            this->excludeList.replace("*",".*");
 
             QRegularExpression regex2(this->excludeList);
 

--- a/src/Dropbox/msdropbox.cpp
+++ b/src/Dropbox/msdropbox.cpp
@@ -516,29 +516,31 @@ bool MSDropbox::filterIncludeFileNames(QString path){// return false if input pa
     if(this->includeList==""){
         return true;
     }
-
-    // catch paths with  beginning masks from include/exclude lists
+    QString filterType = this->getOption("filter-type");
     bool isBegin=false;
-    bool start;
-    QRegularExpression regex3(path);
-    regex3.patternErrorOffset();
-    QRegularExpressionMatch m1= regex3.match(this->includeList);
+    // catch paths with  beginning masks from include/exclude lists
+    QRegExp regex3(path);
+    if(filterType == "regexp")
+        regex3.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex3.setPatternSyntax(QRegExp::Wildcard);
+    regex3.isValid();
+    int m1 = regex3.indexIn(this->includeList);
 
-    if(m1.hasMatch()){
-        start=m1.capturedStart();
-
-        if((this->includeList.mid(start-1,1)=="|") ||(start==0)){
+    if(m1 != -1){
+        if((this->includeList.mid(m1-1,1)=="|") ||(m1==0)){
             isBegin=true;
         }
     }
+    QRegExp regex2(this->includeList);
+    if(filterType == "regexp")
+        regex2.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex2.setPatternSyntax(QRegExp::Wildcard);
+    regex2.isValid();
 
-    QRegularExpression regex2(this->includeList);
-
-    regex2.patternErrorOffset();
-
-    QRegularExpressionMatch m = regex2.match(path);
-
-    if(m.hasMatch()){
+    int m = regex2.indexIn(path);
+    if(m != -1){
         return false;
     }
     else{
@@ -549,6 +551,65 @@ bool MSDropbox::filterIncludeFileNames(QString path){// return false if input pa
             return true;
         }
     }
+
+    /*if(filterType == "regexp"){
+        // catch paths with  beginning masks from include/exclude lists
+        bool start;
+        QRegularExpression regex3(path);
+        regex3.patternErrorOffset();
+        QRegularExpressionMatch m1= regex3.match(this->includeList);
+
+        if(m1.hasMatch()){
+            start=m1.capturedStart();
+            if((this->includeList.mid(start-1,1)=="|") ||(start==0)){
+                isBegin=true;
+            }
+        }
+        QRegularExpression regex2(this->includeList);
+        regex2.patternErrorOffset();
+        QRegularExpressionMatch m = regex2.match(path);
+
+        if(m.hasMatch()){
+            return false;
+        }
+        else{
+            if(isBegin){
+                return false;
+            }
+            else{
+                return true;
+            }
+        }
+    }
+    else{
+        // catch paths with  beginning masks from include/exclude lists
+        QRegExp regex3(path);
+        regex3.setPatternSyntax(QRegExp::Wildcard);
+        regex3.isValid();
+        int m1 = regex3.indexIn(this->includeList);
+
+        if(m1 != -1){
+            if((this->includeList.mid(m1-1,1)=="|") ||(m1==0)){
+                isBegin=true;
+            }
+        }
+        QRegExp regex2(this->includeList);
+        regex2.setPatternSyntax(QRegExp::Wildcard);
+        regex2.isValid();
+
+        int m = regex2.indexIn(path);
+        if(m != -1){
+            return false;
+        }
+        else{
+            if(isBegin){
+                return false;
+            }
+            else{
+                return true;
+            }
+        }
+    }*/
 
 }
 
@@ -559,30 +620,31 @@ bool MSDropbox::filterExcludeFileNames(QString path){// return false if input pa
     if(this->excludeList==""){
         return true;
     }
-
-    // catch paths with  beginning masks from include/exclude lists
+    QString filterType = this->getOption("filter-type");
     bool isBegin=false;
-    bool start;
-    QRegularExpression regex3(path);
-    regex3.patternErrorOffset();
-    QRegularExpressionMatch m1= regex3.match(this->excludeList);
 
-    if(m1.hasMatch()){
-        start=m1.capturedStart();
+    QRegExp regex3(path);
+    if(filterType == "regexp")
+        regex3.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex3.setPatternSyntax(QRegExp::Wildcard);
+    regex3.isValid();
+    int m1 = regex3.indexIn(this->excludeList);
 
-        if((this->excludeList.mid(start-1,1)=="|") ||(start==0)){
+    if(m1 != -1){
+        if((this->excludeList.mid(m1-1,1)=="|") ||(m1==0)){
             isBegin=true;
         }
     }
+    QRegExp regex2(this->excludeList);
+    if(filterType == "regexp")
+        regex2.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex2.setPatternSyntax(QRegExp::Wildcard);
+    regex2.isValid();
 
-
-    QRegularExpression regex2(this->excludeList);
-
-    regex2.patternErrorOffset();
-
-    QRegularExpressionMatch m = regex2.match(path);
-
-    if(m.hasMatch()){
+    int m = regex2.indexIn(path);
+    if(m != -1){
         return false;
     }
     else{
@@ -594,7 +656,64 @@ bool MSDropbox::filterExcludeFileNames(QString path){// return false if input pa
         }
     }
 
+    /*if(filterType == "regexp"){
+        // catch paths with  beginning masks from include/exclude lists
+        bool start;
+        QRegularExpression regex3(path);
+        regex3.patternErrorOffset();
+        QRegularExpressionMatch m1= regex3.match(this->excludeList);
 
+        if(m1.hasMatch()){
+            start=m1.capturedStart();
+            if((this->excludeList.mid(start-1,1)=="|") ||(start==0)){
+                isBegin=true;
+            }
+        }
+        QRegularExpression regex2(this->excludeList);
+        regex2.patternErrorOffset();
+        QRegularExpressionMatch m = regex2.match(path);
+
+        if(m.hasMatch()){
+            return false;
+        }
+        else{
+            if(isBegin){
+                return false;
+            }
+            else{
+                return true;
+            }
+        }
+    }
+    else{
+        // catch paths with  beginning masks from include/exclude lists
+        QRegExp regex3(path);
+        regex3.setPatternSyntax(QRegExp::Wildcard);
+        regex3.isValid();
+        int m1 = regex3.indexIn(this->excludeList);
+
+        if(m1 != -1){
+            if((this->excludeList.mid(m1-1,1)=="|") ||(m1==0)){
+                isBegin=true;
+            }
+        }
+        QRegExp regex2(this->excludeList);
+        regex2.setPatternSyntax(QRegExp::Wildcard);
+        regex2.isValid();
+
+        int m = regex2.indexIn(path);
+        if(m != -1){
+            return false;
+        }
+        else{
+            if(isBegin){
+                return false;
+            }
+            else{
+                return true;
+            }
+        }
+    }*/
 }
 
 //=======================================================================================
@@ -613,17 +732,26 @@ bool MSDropbox::createSyncFileList(){
 
                 line=instream.readLine();
                 if(line.isEmpty()){
-                        continue;
+                    continue;
                 }
-
+                if(instream.pos() == 9 && line == "wildcard"){
+                    this->options.insert("filter-type", "wildcard");
+                    continue;
+                }
+                else if(instream.pos() == 7 && line == "regexp"){
+                    this->options.insert("filter-type", "regexp");
+                    continue;
+                }
                 this->includeList=this->includeList+line+"|";
             }
             this->includeList=this->includeList.left(this->includeList.size()-1);
-            this->includeList.replace("*",".*");
 
-            QRegularExpression regex2(this->includeList);
-
-            if(regex2.patternErrorOffset()!=-1){
+            QRegExp regex2(this->excludeList);
+            if(this->getOption("filter-type") == "regexp")
+                regex2.setPatternSyntax(QRegExp::RegExp);
+            else
+                regex2.setPatternSyntax(QRegExp::Wildcard);
+            if(!regex2.isValid()){
                 qStdOut()<<"Include filelist contains errors. Program will be terminated.";
                 return false;
             }
@@ -639,17 +767,27 @@ bool MSDropbox::createSyncFileList(){
             while(!instream.atEnd()){
 
                 line=instream.readLine();
+                if(instream.pos() == 9 && line == "wildcard"){
+                    this->options.insert("filter-type", "wildcard");
+                    continue;
+                }
+                else if(instream.pos() == 7 && line == "regexp"){
+                    this->options.insert("filter-type", "regexp");
+                    continue;
+                }
                 if(line.isEmpty()){
-                        continue;
+                    continue;
                 }
                 this->excludeList=this->excludeList+line+"|";
             }
             this->excludeList=this->excludeList.left(this->excludeList.size()-1);
-            this->excludeList.replace("*",".*");
 
-            QRegularExpression regex2(this->excludeList);
-
-            if(regex2.patternErrorOffset()!=-1){
+            QRegExp regex2(this->excludeList);
+            if(this->getOption("filter-type") == "regexp")
+                regex2.setPatternSyntax(QRegExp::RegExp);
+            else
+                regex2.setPatternSyntax(QRegExp::Wildcard);
+            if(!regex2.isValid()){
                 qStdOut()<<"Exclude filelist contains errors. Program will be terminated.";
                 return false;
             }

--- a/src/GoogleDrive/msgoogledrive.cpp
+++ b/src/GoogleDrive/msgoogledrive.cpp
@@ -813,29 +813,31 @@ bool MSGoogleDrive::filterIncludeFileNames(QString path){// return false if inpu
     if(this->includeList==""){
         return true;
     }
-
-    // catch paths with  beginning masks from include/exclude lists
+    QString filterType = this->getOption("filter-type");
     bool isBegin=false;
-    bool start;
-    QRegularExpression regex3(path);
-    regex3.patternErrorOffset();
-    QRegularExpressionMatch m1= regex3.match(this->includeList);
+    // catch paths with  beginning masks from include/exclude lists
+    QRegExp regex3(path);
+    if(filterType == "regexp")
+        regex3.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex3.setPatternSyntax(QRegExp::Wildcard);
+    regex3.isValid();
+    int m1 = regex3.indexIn(this->includeList);
 
-    if(m1.hasMatch()){
-        start=m1.capturedStart();
-
-        if((this->includeList.mid(start-1,1)=="|") ||(start==0)){
+    if(m1 != -1){
+        if((this->includeList.mid(m1-1,1)=="|") ||(m1==0)){
             isBegin=true;
         }
     }
+    QRegExp regex2(this->includeList);
+    if(filterType == "regexp")
+        regex2.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex2.setPatternSyntax(QRegExp::Wildcard);
+    regex2.isValid();
 
-    QRegularExpression regex2(this->includeList);
-
-    regex2.patternErrorOffset();
-
-    QRegularExpressionMatch m = regex2.match(path);
-
-    if(m.hasMatch()){
+    int m = regex2.indexIn(path);
+    if(m != -1){
         return false;
     }
     else{
@@ -846,7 +848,6 @@ bool MSGoogleDrive::filterIncludeFileNames(QString path){// return false if inpu
             return true;
         }
     }
-
 }
 
 //=======================================================================================
@@ -856,30 +857,31 @@ bool MSGoogleDrive::filterExcludeFileNames(QString path){// return false if inpu
     if(this->excludeList==""){
         return true;
     }
-
-    // catch paths with  beginning masks from include/exclude lists
+    QString filterType = this->getOption("filter-type");
     bool isBegin=false;
-    bool start;
-    QRegularExpression regex3(path);
-    regex3.patternErrorOffset();
-    QRegularExpressionMatch m1= regex3.match(this->excludeList);
 
-    if(m1.hasMatch()){
-        start=m1.capturedStart();
+    QRegExp regex3(path);
+    if(filterType == "regexp")
+        regex3.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex3.setPatternSyntax(QRegExp::Wildcard);
+    regex3.isValid();
+    int m1 = regex3.indexIn(this->excludeList);
 
-        if((this->excludeList.mid(start-1,1)=="|") ||(start==0)){
+    if(m1 != -1){
+        if((this->excludeList.mid(m1-1,1)=="|") ||(m1==0)){
             isBegin=true;
         }
     }
+    QRegExp regex2(this->excludeList);
+    if(filterType == "regexp")
+        regex2.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex2.setPatternSyntax(QRegExp::Wildcard);
+    regex2.isValid();
 
-
-    QRegularExpression regex2(this->excludeList);
-
-    regex2.patternErrorOffset();
-
-    QRegularExpressionMatch m = regex2.match(path);
-
-    if(m.hasMatch()){
+    int m = regex2.indexIn(path);
+    if(m != -1){
         return false;
     }
     else{
@@ -890,8 +892,6 @@ bool MSGoogleDrive::filterExcludeFileNames(QString path){// return false if inpu
             return true;
         }
     }
-
-
 }
 
 //=======================================================================================
@@ -955,17 +955,26 @@ bool MSGoogleDrive::createSyncFileList(){
 
                 line=instream.readLine();
                 if(line.isEmpty()){
-                        continue;
+                    continue;
                 }
-
+                if(instream.pos() == 9 && line == "wildcard"){
+                    this->options.insert("filter-type", "wildcard");
+                    continue;
+                }
+                else if(instream.pos() == 7 && line == "regexp"){
+                    this->options.insert("filter-type", "regexp");
+                    continue;
+                }
                 this->includeList=this->includeList+line+"|";
             }
             this->includeList=this->includeList.left(this->includeList.size()-1);
-            this->includeList.replace("*",".*");
 
-            QRegularExpression regex2(this->includeList);
-
-            if(regex2.patternErrorOffset()!=-1){
+            QRegExp regex2(this->excludeList);
+            if(this->getOption("filter-type") == "regexp")
+                regex2.setPatternSyntax(QRegExp::RegExp);
+            else
+                regex2.setPatternSyntax(QRegExp::Wildcard);
+            if(!regex2.isValid()){
                 qStdOut()<<"Include filelist contains errors. Program will be terminated.";
                 return false;
             }
@@ -981,23 +990,32 @@ bool MSGoogleDrive::createSyncFileList(){
             while(!instream.atEnd()){
 
                 line=instream.readLine();
+                if(instream.pos() == 9 && line == "wildcard"){
+                    this->options.insert("filter-type", "wildcard");
+                    continue;
+                }
+                else if(instream.pos() == 7 && line == "regexp"){
+                    this->options.insert("filter-type", "regexp");
+                    continue;
+                }
                 if(line.isEmpty()){
-                        continue;
+                    continue;
                 }
                 this->excludeList=this->excludeList+line+"|";
             }
             this->excludeList=this->excludeList.left(this->excludeList.size()-1);
-            this->excludeList.replace("*",".*");
 
-            QRegularExpression regex2(this->excludeList);
-
-            if(regex2.patternErrorOffset()!=-1){
+            QRegExp regex2(this->excludeList);
+            if(this->getOption("filter-type") == "regexp")
+                regex2.setPatternSyntax(QRegExp::RegExp);
+            else
+                regex2.setPatternSyntax(QRegExp::Wildcard);
+            if(!regex2.isValid()){
                 qStdOut()<<"Exclude filelist contains errors. Program will be terminated.";
                 return false;
             }
         }
     }
-
 
     qStdOut()<< "Reading remote files"<<endl;
 

--- a/src/GoogleDrive/msgoogledrive.cpp
+++ b/src/GoogleDrive/msgoogledrive.cpp
@@ -953,7 +953,7 @@ bool MSGoogleDrive::createSyncFileList(){
             QString line;
             while(!instream.atEnd()){
 
-                QString line=instream.readLine();
+                line=instream.readLine();
                 if(line.isEmpty()){
                         continue;
                 }
@@ -961,6 +961,7 @@ bool MSGoogleDrive::createSyncFileList(){
                 this->includeList=this->includeList+line+"|";
             }
             this->includeList=this->includeList.left(this->includeList.size()-1);
+            this->includeList.replace("*",".*");
 
             QRegularExpression regex2(this->includeList);
 
@@ -968,7 +969,6 @@ bool MSGoogleDrive::createSyncFileList(){
                 qStdOut()<<"Include filelist contains errors. Program will be terminated.";
                 return false;
             }
-
         }
     }
     else{
@@ -980,13 +980,14 @@ bool MSGoogleDrive::createSyncFileList(){
             QString line;
             while(!instream.atEnd()){
 
-                QString line=instream.readLine();
+                line=instream.readLine();
                 if(line.isEmpty()){
                         continue;
                 }
                 this->excludeList=this->excludeList+line+"|";
             }
             this->excludeList=this->excludeList.left(this->excludeList.size()-1);
+            this->excludeList.replace("*",".*");
 
             QRegularExpression regex2(this->excludeList);
 

--- a/src/MailRu/msmailru.cpp
+++ b/src/MailRu/msmailru.cpp
@@ -1840,12 +1840,13 @@ bool MSMailRu::createSyncFileList(){
             QString line;
             while(!instream.atEnd()){
 
-                QString line=instream.readLine();
+                line=instream.readLine();
                 if(line.isEmpty()){
                         continue;
                 }
 
                 this->includeList=this->includeList+line+"|";
+                this->includeList.replace("*",".*");
             }
             this->includeList=this->includeList.left(this->includeList.size()-1);
 
@@ -1855,7 +1856,6 @@ bool MSMailRu::createSyncFileList(){
                 qStdOut()<<"Include filelist contains errors. Program will be terminated.";
                 return false;
             }
-
         }
     }
     else{
@@ -1867,13 +1867,14 @@ bool MSMailRu::createSyncFileList(){
             QString line;
             while(!instream.atEnd()){
 
-                QString line=instream.readLine();
+                line=instream.readLine();
                 if(line.isEmpty()){
                         continue;
                 }
                 this->excludeList=this->excludeList+line+"|";
             }
             this->excludeList=this->excludeList.left(this->excludeList.size()-1);
+            this->excludeList.replace("*",".*");
 
             QRegularExpression regex2(this->excludeList);
 

--- a/src/MailRu/msmailru.cpp
+++ b/src/MailRu/msmailru.cpp
@@ -1745,29 +1745,31 @@ bool MSMailRu::filterIncludeFileNames(QString path){
     if(this->includeList==""){
         return true;
     }
-
-    // catch paths with  beginning masks from include/exclude lists
+    QString filterType = this->getOption("filter-type");
     bool isBegin=false;
-    bool start;
-    QRegularExpression regex3(path);
-    regex3.patternErrorOffset();
-    QRegularExpressionMatch m1= regex3.match(this->includeList);
+    // catch paths with  beginning masks from include/exclude lists
+    QRegExp regex3(path);
+    if(filterType == "regexp")
+        regex3.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex3.setPatternSyntax(QRegExp::Wildcard);
+    regex3.isValid();
+    int m1 = regex3.indexIn(this->includeList);
 
-    if(m1.hasMatch()){
-        start=m1.capturedStart();
-
-        if((this->includeList.mid(start-1,1)=="|") ||(start==0)){
+    if(m1 != -1){
+        if((this->includeList.mid(m1-1,1)=="|") ||(m1==0)){
             isBegin=true;
         }
     }
+    QRegExp regex2(this->includeList);
+    if(filterType == "regexp")
+        regex2.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex2.setPatternSyntax(QRegExp::Wildcard);
+    regex2.isValid();
 
-    QRegularExpression regex2(this->includeList);
-
-    regex2.patternErrorOffset();
-
-    QRegularExpressionMatch m = regex2.match(path);
-
-    if(m.hasMatch()){
+    int m = regex2.indexIn(path);
+    if(m != -1){
         return false;
     }
     else{
@@ -1788,30 +1790,31 @@ bool MSMailRu::filterExcludeFileNames(QString path){
     if(this->excludeList==""){
         return true;
     }
-
-    // catch paths with  beginning masks from include/exclude lists
+    QString filterType = this->getOption("filter-type");
     bool isBegin=false;
-    bool start;
-    QRegularExpression regex3(path);
-    regex3.patternErrorOffset();
-    QRegularExpressionMatch m1= regex3.match(this->excludeList);
 
-    if(m1.hasMatch()){
-        start=m1.capturedStart();
+    QRegExp regex3(path);
+    if(filterType == "regexp")
+        regex3.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex3.setPatternSyntax(QRegExp::Wildcard);
+    regex3.isValid();
+    int m1 = regex3.indexIn(this->excludeList);
 
-        if((this->excludeList.mid(start-1,1)=="|") ||(start==0)){
+    if(m1 != -1){
+        if((this->excludeList.mid(m1-1,1)=="|") ||(m1==0)){
             isBegin=true;
         }
     }
+    QRegExp regex2(this->excludeList);
+    if(filterType == "regexp")
+        regex2.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex2.setPatternSyntax(QRegExp::Wildcard);
+    regex2.isValid();
 
-
-    QRegularExpression regex2(this->excludeList);
-
-    regex2.patternErrorOffset();
-
-    QRegularExpressionMatch m = regex2.match(path);
-
-    if(m.hasMatch()){
+    int m = regex2.indexIn(path);
+    if(m != -1){
         return false;
     }
     else{
@@ -1822,8 +1825,6 @@ bool MSMailRu::filterExcludeFileNames(QString path){
             return true;
         }
     }
-
-
 }
 
 //=======================================================================================
@@ -1842,17 +1843,26 @@ bool MSMailRu::createSyncFileList(){
 
                 line=instream.readLine();
                 if(line.isEmpty()){
-                        continue;
+                    continue;
                 }
-
+                if(instream.pos() == 9 && line == "wildcard"){
+                    this->options.insert("filter-type", "wildcard");
+                    continue;
+                }
+                else if(instream.pos() == 7 && line == "regexp"){
+                    this->options.insert("filter-type", "regexp");
+                    continue;
+                }
                 this->includeList=this->includeList+line+"|";
-                this->includeList.replace("*",".*");
             }
             this->includeList=this->includeList.left(this->includeList.size()-1);
 
-            QRegularExpression regex2(this->includeList);
-
-            if(regex2.patternErrorOffset()!=-1){
+            QRegExp regex2(this->excludeList);
+            if(this->getOption("filter-type") == "regexp")
+                regex2.setPatternSyntax(QRegExp::RegExp);
+            else
+                regex2.setPatternSyntax(QRegExp::Wildcard);
+            if(!regex2.isValid()){
                 qStdOut()<<"Include filelist contains errors. Program will be terminated.";
                 return false;
             }
@@ -1868,23 +1878,32 @@ bool MSMailRu::createSyncFileList(){
             while(!instream.atEnd()){
 
                 line=instream.readLine();
+                if(instream.pos() == 9 && line == "wildcard"){
+                    this->options.insert("filter-type", "wildcard");
+                    continue;
+                }
+                else if(instream.pos() == 7 && line == "regexp"){
+                    this->options.insert("filter-type", "regexp");
+                    continue;
+                }
                 if(line.isEmpty()){
-                        continue;
+                    continue;
                 }
                 this->excludeList=this->excludeList+line+"|";
             }
             this->excludeList=this->excludeList.left(this->excludeList.size()-1);
-            this->excludeList.replace("*",".*");
 
-            QRegularExpression regex2(this->excludeList);
-
-            if(regex2.patternErrorOffset()!=-1){
+            QRegExp regex2(this->excludeList);
+            if(this->getOption("filter-type") == "regexp")
+                regex2.setPatternSyntax(QRegExp::RegExp);
+            else
+                regex2.setPatternSyntax(QRegExp::Wildcard);
+            if(!regex2.isValid()){
                 qStdOut()<<"Exclude filelist contains errors. Program will be terminated.";
                 return false;
             }
         }
     }
-
 
     qStdOut()<< "Reading remote files"<<endl;
 

--- a/src/OneDrive/msonedrive.cpp
+++ b/src/OneDrive/msonedrive.cpp
@@ -1713,12 +1713,13 @@ bool MSOneDrive::createSyncFileList(){
             QString line;
             while(!instream.atEnd()){
 
-                QString line=instream.readLine();
+                line=instream.readLine();
                 if(line.isEmpty()){
                         continue;
                 }
 
                 this->includeList=this->includeList+line+"|";
+                this->includeList.replace("*",".*");
             }
             this->includeList=this->includeList.left(this->includeList.size()-1);
 
@@ -1728,7 +1729,6 @@ bool MSOneDrive::createSyncFileList(){
                 qStdOut()<<"Include filelist contains errors. Program will be terminated.";
                 return false;
             }
-
         }
     }
     else{
@@ -1740,11 +1740,12 @@ bool MSOneDrive::createSyncFileList(){
             QString line;
             while(!instream.atEnd()){
 
-                QString line=instream.readLine();
+                line=instream.readLine();
                 if(line.isEmpty()){
                         continue;
                 }
                 this->excludeList=this->excludeList+line+"|";
+                this->excludeList.replace("*",".*");
             }
             this->excludeList=this->excludeList.left(this->excludeList.size()-1);
 

--- a/src/OneDrive/msonedrive.cpp
+++ b/src/OneDrive/msonedrive.cpp
@@ -1619,29 +1619,31 @@ bool MSOneDrive::filterIncludeFileNames(QString path){
     if(this->includeList==""){
         return true;
     }
-
-    // catch paths with  beginning masks from include/exclude lists
+    QString filterType = this->getOption("filter-type");
     bool isBegin=false;
-    bool start;
-    QRegularExpression regex3(path);
-    regex3.patternErrorOffset();
-    QRegularExpressionMatch m1= regex3.match(this->includeList);
+    // catch paths with  beginning masks from include/exclude lists
+    QRegExp regex3(path);
+    if(filterType == "regexp")
+        regex3.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex3.setPatternSyntax(QRegExp::Wildcard);
+    regex3.isValid();
+    int m1 = regex3.indexIn(this->includeList);
 
-    if(m1.hasMatch()){
-        start=m1.capturedStart();
-
-        if((this->includeList.mid(start-1,1)=="|") ||(start==0)){
+    if(m1 != -1){
+        if((this->includeList.mid(m1-1,1)=="|") ||(m1==0)){
             isBegin=true;
         }
     }
+    QRegExp regex2(this->includeList);
+    if(filterType == "regexp")
+        regex2.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex2.setPatternSyntax(QRegExp::Wildcard);
+    regex2.isValid();
 
-    QRegularExpression regex2(this->includeList);
-
-    regex2.patternErrorOffset();
-
-    QRegularExpressionMatch m = regex2.match(path);
-
-    if(m.hasMatch()){
+    int m = regex2.indexIn(path);
+    if(m != -1){
         return false;
     }
     else{
@@ -1661,30 +1663,31 @@ bool MSOneDrive::filterExcludeFileNames(QString path){
     if(this->excludeList==""){
         return true;
     }
-
-    // catch paths with  beginning masks from include/exclude lists
+    QString filterType = this->getOption("filter-type");
     bool isBegin=false;
-    bool start;
-    QRegularExpression regex3(path);
-    regex3.patternErrorOffset();
-    QRegularExpressionMatch m1= regex3.match(this->excludeList);
 
-    if(m1.hasMatch()){
-        start=m1.capturedStart();
+    QRegExp regex3(path);
+    if(filterType == "regexp")
+        regex3.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex3.setPatternSyntax(QRegExp::Wildcard);
+    regex3.isValid();
+    int m1 = regex3.indexIn(this->excludeList);
 
-        if((this->excludeList.mid(start-1,1)=="|") ||(start==0)){
+    if(m1 != -1){
+        if((this->excludeList.mid(m1-1,1)=="|") ||(m1==0)){
             isBegin=true;
         }
     }
+    QRegExp regex2(this->excludeList);
+    if(filterType == "regexp")
+        regex2.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex2.setPatternSyntax(QRegExp::Wildcard);
+    regex2.isValid();
 
-
-    QRegularExpression regex2(this->excludeList);
-
-    regex2.patternErrorOffset();
-
-    QRegularExpressionMatch m = regex2.match(path);
-
-    if(m.hasMatch()){
+    int m = regex2.indexIn(path);
+    if(m != -1){
         return false;
     }
     else{
@@ -1695,12 +1698,7 @@ bool MSOneDrive::filterExcludeFileNames(QString path){
             return true;
         }
     }
-
-
-
 }
-
-
 
 bool MSOneDrive::createSyncFileList(){
 
@@ -1715,17 +1713,26 @@ bool MSOneDrive::createSyncFileList(){
 
                 line=instream.readLine();
                 if(line.isEmpty()){
-                        continue;
+                    continue;
                 }
-
+                if(instream.pos() == 9 && line == "wildcard"){
+                    this->options.insert("filter-type", "wildcard");
+                    continue;
+                }
+                else if(instream.pos() == 7 && line == "regexp"){
+                    this->options.insert("filter-type", "regexp");
+                    continue;
+                }
                 this->includeList=this->includeList+line+"|";
-                this->includeList.replace("*",".*");
             }
             this->includeList=this->includeList.left(this->includeList.size()-1);
 
-            QRegularExpression regex2(this->includeList);
-
-            if(regex2.patternErrorOffset()!=-1){
+            QRegExp regex2(this->excludeList);
+            if(this->getOption("filter-type") == "regexp")
+                regex2.setPatternSyntax(QRegExp::RegExp);
+            else
+                regex2.setPatternSyntax(QRegExp::Wildcard);
+            if(!regex2.isValid()){
                 qStdOut()<<"Include filelist contains errors. Program will be terminated.";
                 return false;
             }
@@ -1741,23 +1748,32 @@ bool MSOneDrive::createSyncFileList(){
             while(!instream.atEnd()){
 
                 line=instream.readLine();
+                if(instream.pos() == 9 && line == "wildcard"){
+                    this->options.insert("filter-type", "wildcard");
+                    continue;
+                }
+                else if(instream.pos() == 7 && line == "regexp"){
+                    this->options.insert("filter-type", "regexp");
+                    continue;
+                }
                 if(line.isEmpty()){
-                        continue;
+                    continue;
                 }
                 this->excludeList=this->excludeList+line+"|";
-                this->excludeList.replace("*",".*");
             }
             this->excludeList=this->excludeList.left(this->excludeList.size()-1);
 
-            QRegularExpression regex2(this->excludeList);
-
-            if(regex2.patternErrorOffset()!=-1){
+            QRegExp regex2(this->excludeList);
+            if(this->getOption("filter-type") == "regexp")
+                regex2.setPatternSyntax(QRegExp::RegExp);
+            else
+                regex2.setPatternSyntax(QRegExp::Wildcard);
+            if(!regex2.isValid()){
                 qStdOut()<<"Exclude filelist contains errors. Program will be terminated.";
                 return false;
             }
         }
     }
-
 
     qStdOut()<< "Reading remote files"<<endl;
 

--- a/src/YandexDisk/msyandexdisk.cpp
+++ b/src/YandexDisk/msyandexdisk.cpp
@@ -573,12 +573,13 @@ bool MSYandexDisk::createSyncFileList(){
             QString line;
             while(!instream.atEnd()){
 
-                QString line=instream.readLine();
+                line=instream.readLine();
                 if(line.isEmpty()){
                         continue;
                 }
 
                 this->includeList=this->includeList+line+"|";
+                this->includeList.replace("*",".*");
             }
             this->includeList=this->includeList.left(this->includeList.size()-1);
 
@@ -588,7 +589,6 @@ bool MSYandexDisk::createSyncFileList(){
                 qStdOut()<<"Include filelist contains errors. Program will be terminated.";
                 return false;
             }
-
         }
     }
     else{
@@ -600,11 +600,12 @@ bool MSYandexDisk::createSyncFileList(){
             QString line;
             while(!instream.atEnd()){
 
-                QString line=instream.readLine();
+                line=instream.readLine();
                 if(line.isEmpty()){
                         continue;
                 }
                 this->excludeList=this->excludeList+line+"|";
+                this->excludeList.replace("*",".*");
             }
             this->excludeList=this->excludeList.left(this->excludeList.size()-1);
 

--- a/src/YandexDisk/msyandexdisk.cpp
+++ b/src/YandexDisk/msyandexdisk.cpp
@@ -478,29 +478,31 @@ bool MSYandexDisk::filterIncludeFileNames(QString path){// return false if input
     if(this->includeList==""){
         return true;
     }
-
-    // catch paths with  beginning masks from include/exclude lists
+    QString filterType = this->getOption("filter-type");
     bool isBegin=false;
-    bool start;
-    QRegularExpression regex3(path);
-    regex3.patternErrorOffset();
-    QRegularExpressionMatch m1= regex3.match(this->includeList);
+    // catch paths with  beginning masks from include/exclude lists
+    QRegExp regex3(path);
+    if(filterType == "regexp")
+        regex3.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex3.setPatternSyntax(QRegExp::Wildcard);
+    regex3.isValid();
+    int m1 = regex3.indexIn(this->includeList);
 
-    if(m1.hasMatch()){
-        start=m1.capturedStart();
-
-        if((this->includeList.mid(start-1,1)=="|") ||(start==0)){
+    if(m1 != -1){
+        if((this->includeList.mid(m1-1,1)=="|") ||(m1==0)){
             isBegin=true;
         }
     }
+    QRegExp regex2(this->includeList);
+    if(filterType == "regexp")
+        regex2.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex2.setPatternSyntax(QRegExp::Wildcard);
+    regex2.isValid();
 
-    QRegularExpression regex2(this->includeList);
-
-    regex2.patternErrorOffset();
-
-    QRegularExpressionMatch m = regex2.match(path);
-
-    if(m.hasMatch()){
+    int m = regex2.indexIn(path);
+    if(m != -1){
         return false;
     }
     else{
@@ -511,7 +513,6 @@ bool MSYandexDisk::filterIncludeFileNames(QString path){// return false if input
             return true;
         }
     }
-
 }
 
 //=======================================================================================
@@ -521,30 +522,31 @@ bool MSYandexDisk::filterExcludeFileNames(QString path){// return false if input
     if(this->excludeList==""){
         return true;
     }
-
-    // catch paths with  beginning masks from include/exclude lists
+    QString filterType = this->getOption("filter-type");
     bool isBegin=false;
-    bool start;
-    QRegularExpression regex3(path);
-    regex3.patternErrorOffset();
-    QRegularExpressionMatch m1= regex3.match(this->excludeList);
 
-    if(m1.hasMatch()){
-        start=m1.capturedStart();
+    QRegExp regex3(path);
+    if(filterType == "regexp")
+        regex3.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex3.setPatternSyntax(QRegExp::Wildcard);
+    regex3.isValid();
+    int m1 = regex3.indexIn(this->excludeList);
 
-        if((this->excludeList.mid(start-1,1)=="|") ||(start==0)){
+    if(m1 != -1){
+        if((this->excludeList.mid(m1-1,1)=="|") ||(m1==0)){
             isBegin=true;
         }
     }
+    QRegExp regex2(this->excludeList);
+    if(filterType == "regexp")
+        regex2.setPatternSyntax(QRegExp::RegExp);
+    else
+        regex2.setPatternSyntax(QRegExp::Wildcard);
+    regex2.isValid();
 
-
-    QRegularExpression regex2(this->excludeList);
-
-    regex2.patternErrorOffset();
-
-    QRegularExpressionMatch m = regex2.match(path);
-
-    if(m.hasMatch()){
+    int m = regex2.indexIn(path);
+    if(m != -1){
         return false;
     }
     else{
@@ -555,8 +557,6 @@ bool MSYandexDisk::filterExcludeFileNames(QString path){// return false if input
             return true;
         }
     }
-
-
 }
 
 //=======================================================================================
@@ -575,17 +575,26 @@ bool MSYandexDisk::createSyncFileList(){
 
                 line=instream.readLine();
                 if(line.isEmpty()){
-                        continue;
+                    continue;
                 }
-
+                if(instream.pos() == 9 && line == "wildcard"){
+                    this->options.insert("filter-type", "wildcard");
+                    continue;
+                }
+                else if(instream.pos() == 7 && line == "regexp"){
+                    this->options.insert("filter-type", "regexp");
+                    continue;
+                }
                 this->includeList=this->includeList+line+"|";
-                this->includeList.replace("*",".*");
             }
             this->includeList=this->includeList.left(this->includeList.size()-1);
 
-            QRegularExpression regex2(this->includeList);
-
-            if(regex2.patternErrorOffset()!=-1){
+            QRegExp regex2(this->excludeList);
+            if(this->getOption("filter-type") == "regexp")
+                regex2.setPatternSyntax(QRegExp::RegExp);
+            else
+                regex2.setPatternSyntax(QRegExp::Wildcard);
+            if(!regex2.isValid()){
                 qStdOut()<<"Include filelist contains errors. Program will be terminated.";
                 return false;
             }
@@ -601,23 +610,32 @@ bool MSYandexDisk::createSyncFileList(){
             while(!instream.atEnd()){
 
                 line=instream.readLine();
+                if(instream.pos() == 9 && line == "wildcard"){
+                    this->options.insert("filter-type", "wildcard");
+                    continue;
+                }
+                else if(instream.pos() == 7 && line == "regexp"){
+                    this->options.insert("filter-type", "regexp");
+                    continue;
+                }
                 if(line.isEmpty()){
-                        continue;
+                    continue;
                 }
                 this->excludeList=this->excludeList+line+"|";
-                this->excludeList.replace("*",".*");
             }
             this->excludeList=this->excludeList.left(this->excludeList.size()-1);
 
-            QRegularExpression regex2(this->excludeList);
-
-            if(regex2.patternErrorOffset()!=-1){
+            QRegExp regex2(this->excludeList);
+            if(this->getOption("filter-type") == "regexp")
+                regex2.setPatternSyntax(QRegExp::RegExp);
+            else
+                regex2.setPatternSyntax(QRegExp::Wildcard);
+            if(!regex2.isValid()){
                 qStdOut()<<"Exclude filelist contains errors. Program will be terminated.";
                 return false;
             }
         }
     }
-
 
     qStdOut()<< "Reading remote files"<<endl;
 

--- a/src/common/msoptparser.cpp
+++ b/src/common/msoptparser.cpp
@@ -260,7 +260,7 @@ int MSOptParser::get(){
               else{
                     this->optarg.clear();
               }
-              *this->iit++;
+              this->iit++;
               return this->opts[i].num;
           }
 

--- a/src/common/msrequest.cpp
+++ b/src/common/msrequest.cpp
@@ -87,7 +87,7 @@ void MSRequest::addQueryItem(QString itemName, QString itemValue){
 
 
 bool MSRequest::setMethod(QString method){
-    if((method=="post")||(method=="get")|(method=="put")){
+    if((method=="post")||(method=="get")||(method=="put")){
         this->requestMethod=method;
         return true;
     }


### PR DESCRIPTION
Правильная интерпретация символа "*" в файлах .exclude и .include. Т.е. можно указать *.jpg, чтобы выбрать все файлы одного типа или *частьназвания*
И убрано лишнее определение переменной в цикле при сборке строки фильтра