### PR TITLE
Fix jobs splitting between threads

### DIFF
--- a/ccross-app/src/OneDrive/msonedrive.cpp
+++ b/ccross-app/src/OneDrive/msonedrive.cpp
@@ -1957,18 +1957,11 @@ bool MSOneDrive::createSyncFileList(){
 //        QHash<QString,MSFSObject> L2;
 //        QHash<QString,MSFSObject> L3;
 
-        for(int i=0;i<keys.size();i+=3){
-
-            if(i<=keys.size()-1){
-                thr1->threadSyncList.insert(keys[i],this->syncFileList.find(keys[i]).value());
-            }
-            if(i+1 <= keys.size()-1){
-                thr2->threadSyncList.insert(keys[i+1],this->syncFileList.find(keys[i+1]).value());
-            }
-            if(i+2 <= keys.size()-1){
-                thr3->threadSyncList.insert(keys[i+2],this->syncFileList.find(keys[i+2]).value());
-            }
-
+        MSSyncThread* threads[3] = {thr1, thr2, thr3};
+        int j = 0;
+        for(int i = 0; i<keys.size(); i++ ){
+            threads[j++]->threadSyncList.insert(keys[i],this->syncFileList.find(keys[i]).value());
+            if (j == 3) j = 0;
         }
         //this->doSync(L2);
 


### PR DESCRIPTION
`for(int i=0;i<keys.size();i+=3){`
will be called only once for keys.size() == 5 and last 2 keys won't be processed.